### PR TITLE
Fixed LifetimeValidator not using correct time zone

### DIFF
--- a/JwtAuthentication.AsymmetricEncryption/Extensions/AuthenticationExtensions.cs
+++ b/JwtAuthentication.AsymmetricEncryption/Extensions/AuthenticationExtensions.cs
@@ -38,7 +38,7 @@ namespace JwtAuthentication.AsymmetricEncryption.Extensions
             SecurityToken securityToken,
             TokenValidationParameters validationParameters)
         {
-            return expires != null && expires > DateTime.Now;
+            return expires != null && expires > DateTime.UtcNow;
         }
     }
 }

--- a/JwtAuthentication.SymmetricEncryption/Extensions/AuthenticationExtensions.cs
+++ b/JwtAuthentication.SymmetricEncryption/Extensions/AuthenticationExtensions.cs
@@ -37,7 +37,7 @@ namespace JwtAuthentication.SymmetricEncryption.Extensions
             SecurityToken securityToken,
             TokenValidationParameters validationParameters)
         {
-            return expires != null && expires > DateTime.Now;
+            return expires != null && expires > DateTime.UtcNow;
         }
     }
 }


### PR DESCRIPTION
The `GetTokenDescriptor()` method in your code uses `DateTime.UtcNow.AddDays(expiringDays)` with `expiringDays` set to 7. This is fine because it hides the issue, but the issue shows when you want an expiration time in hours. For example, if we use `DateTime.UtcNow.AddHours(1)` for a 1 hour expiration on a system where it's time zone is 1 hour ahead (UTC+1), the token generated is already expired because the `LifetimeValidator()` method is using `DateTime.Now`, which looks at the current time zone only. In theory, this would affect any country that is ahead of UTC and the number of hours chosen for expiration is equal or less than the number of hours in from the UTC time zone. A similar issue affects those behind the UTC time zone as well. The solution is to use UTC time for both methods.